### PR TITLE
[여럿이-8] Input, Button 컴포넌트 구현

### DIFF
--- a/src/common/Button.jsx
+++ b/src/common/Button.jsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+// 추후 사용할 색상(팔레트) 정의
+const COLOR = {
+  MAIN: '#B4D9A9',
+  SUB: '#D5D9C4',
+  DARKMAIN: '#94B58B',  // 버튼 active 시에 사용
+};
+
+const Button = ({width='100%', children, ...res}) => {
+  return <ButtonWrapper width={width} {...res}>{children}</ButtonWrapper>
+}
+
+export default Button;
+
+const ButtonWrapper = styled.button`
+  font-size: 20px;
+  padding: 8px 16px;
+  border: 0;
+  border-radius: 5px;
+  background-color: ${COLOR.MAIN};
+  color: white;
+  ${({width})=>`width: ${width};`}
+  ${({ disabled }) => disabled ?
+  `opacity: 0.4; cursor: default;`
+  : `&:active{ background-color: ${COLOR.DARKMAIN}; color: gray; cursor: default;`}
+`

--- a/src/common/Button.jsx
+++ b/src/common/Button.jsx
@@ -1,0 +1,27 @@
+import styled from 'styled-components';
+
+// 추후 사용할 색상(팔레트) 정의
+const COLOR = {
+  MAIN: '#B4D9A9',
+  SUB: '#D5D9C4',
+  DARKMAIN: '#94B58B',  // 버튼 active 시에 사용
+};
+
+const Button = ({width='100%', children, ...res}) => {
+  return <ButtonWrapper width={width} {...res}>{children}</ButtonWrapper>
+}
+
+export default Button;
+
+const ButtonWrapper = styled.button`
+  ${({width})=>`width: ${width};`}
+  padding: 8px 16px;
+  border: 0;
+  border-radius: 5px;
+  background-color: ${COLOR.MAIN};
+  font-size: 20px;
+  color: white;
+  ${({ disabled }) => disabled ?
+  `opacity: 0.4; cursor: default;`
+  : `&:active{ background-color: ${COLOR.DARKMAIN}; color: gray; cursor: default;`}
+`

--- a/src/common/Input.jsx
+++ b/src/common/Input.jsx
@@ -1,0 +1,49 @@
+import styled from 'styled-components';
+
+// 추후 사용할 색상(팔레트) 정의
+const COLOR = {
+  MAIN: '#B4D9A9',
+  SUB: '#D5D9C4',
+};
+
+const Input = ({ width='auto', onReset=null,  ...res }) => {
+  return (
+    <InputWrapper width={width}>
+      <InputBox {...res} adPadding={onReset} />
+      {onReset && <RemoveIcon onClick={onReset}>&times;</RemoveIcon>}
+    </InputWrapper>);
+};
+
+export default Input;
+
+const InputWrapper = styled.div`
+  position: relative;
+  display: block;
+  padding: 8px 16px;
+  ${({ width }) => width ? `width: ${width}` : null}; 
+  border: 2px solid ${COLOR.MAIN};
+  border-radius: 5px;
+  transition: all 0.2s;
+  &:focus-within{
+    box-shadow: 0 0 8px ${COLOR.SUB};
+  }
+`
+
+const InputBox = styled.input`
+  display: inline-block;
+  width: 100%;
+  border: 0;
+  padding: 0;
+  ${({ adPadding })=>adPadding&&`padding-right: 0.6rem`};
+  font-size: 1rem;
+`
+
+const RemoveIcon = styled.span`
+  position: absolute;
+  right: 0.5rem;
+  bottom: 0.5rem;
+  display: inline-block;
+  &:hover {
+    cursor: pointer;
+  }
+`

--- a/src/common/Input.jsx
+++ b/src/common/Input.jsx
@@ -17,10 +17,10 @@ const Input = ({ width='auto', onReset=null,  ...res }) => {
 export default Input;
 
 const InputWrapper = styled.div`
-  position: relative;
   display: block;
-  padding: 8px 16px;
+  position: relative;
   ${({ width }) => width ? `width: ${width}` : null}; 
+  padding: 8px 16px;
   border: 2px solid ${COLOR.MAIN};
   border-radius: 5px;
   transition: all 0.2s;
@@ -39,10 +39,10 @@ const InputBox = styled.input`
 `
 
 const RemoveIcon = styled.span`
+  display: inline-block;
   position: absolute;
   right: 0.5rem;
   bottom: 0.5rem;
-  display: inline-block;
   &:hover {
     cursor: pointer;
   }

--- a/src/hook/useInput.jsx
+++ b/src/hook/useInput.jsx
@@ -1,0 +1,11 @@
+import {useState} from 'react';
+
+const useInput = () => {
+  const [input, setInput] = useState('');
+  const reset = () => setInput('');
+
+  const onChange = e => setInput(e.target.value);    
+  return [input, onChange, reset];
+}
+
+export default useInput;


### PR DESCRIPTION
### 작업한 내용
- input의 기본적인 상태(`value`, `onChange`, `onReset`)를 관리할 수 있는 `useInput`를 구현하였습니다. 
- `Input`과 `Button` 컴포넌트 구현하였습니다.
<img width=500 src='https://user-images.githubusercontent.com/66225688/211411197-97caffc8-b159-4a3c-92a6-2c422f86fb34.png' />

Input focus 효과
<img width=500 src=https://user-images.githubusercontent.com/66225688/211470369-c3266fc6-5af8-4f3d-8b31-6cef89db8d71.png />

Button hover 효과
<img width=500 src=https://user-images.githubusercontent.com/66225688/211411692-e7a80da3-1542-433c-a032-d74d58c6d080.png />

---

### 리뷰 시 참고사항
- 기본적으로 구현된 `Input`과 `Button`은 부모 요소의 `padding`을 제외한 `width`를 채웁니다. 
너비를 지정하고 싶다면 부모 요소의 너비를 조절하거나 `width` 속성으로 원하는 너비값을 전달해주세요.
- `Input` 컴포넌트에 `useInput`으로 전달받은 `onReset` 함수를 넘겨주어 지우는 버튼을 추가할 수 있습니다. 
---

### 고민 중인 부분

---

### 참고 자료

- MAIN과 SUB색상은 https://colorbada.com/colorbada/5515/ 를 참고하였습니다.

issue: #8 

---
