### PR TITLE
[여럿이-27] react-query 재사용 모듈 구현 및 스터디룸 api 연결

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,16 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^5.14.1",
-    "@testing-library/react": "^13.0.0",
-    "@testing-library/user-event": "^13.2.1",
-    "@types/jest": "^27.0.1",
-    "@types/node": "^16.7.13",
-    "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0",
     "axios": "^1.2.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-query": "^3.39.3",
     "react-router-dom": "^6.6.1",
     "react-scripts": "5.0.1",
     "recoil": "^0.7.6",
@@ -45,6 +39,13 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^5.14.1",
+    "@testing-library/react": "^13.0.0",
+    "@testing-library/user-event": "^13.2.1",
+    "@types/jest": "^27.0.1",
+    "@types/node": "^16.7.13",
+    "@types/react": "^18.0.0",
+    "@types/react-dom": "^18.0.0",
     "@types/styled-components": "^5.1.26"
   }
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,10 +6,20 @@ import { Routes, Route } from "react-router-dom";
 import { RecoilRoot } from "recoil";
 import StudyHome from "./containers/StudyRoom/StudyHome";
 import StudyRoomDetail from "./containers/StudyRoom/StudyRoomDetail";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      staleTime: 300000,
+    },
+  },
+});
 
 function App() {
   return (
-    <>
+    <QueryClientProvider client={queryClient}>
       <RecoilRoot>
         <GlobalStyles />
         <Routes>
@@ -19,7 +29,7 @@ function App() {
           <Route path="/studyroom/detail/:rid" element={<StudyRoomDetail />} />
         </Routes>
       </RecoilRoot>
-    </>
+    </QueryClientProvider>
   );
 }
 

--- a/src/api/common/RequestCore.ts
+++ b/src/api/common/RequestCore.ts
@@ -16,10 +16,13 @@ class RequestCore {
   public apiRequest = <T, P>({
     requestMethod,
     requestData,
+    url,
   }: {
     requestMethod: AxiosMethod;
     requestData?: T;
+    url: string;
   }) => {
+    this.url += url;
     if (!this.client) {
       console.error("API client 없음");
       return;

--- a/src/api/roomUser/Resource.ts
+++ b/src/api/roomUser/Resource.ts
@@ -1,0 +1,26 @@
+import roomUserRequest from ".";
+import {
+  createRequest,
+  createRequestWithQuery,
+  createResourceWithQuery,
+} from "../../hooks/react_query_hooks/useResource";
+
+export const ROOM_USER_POST = createRequest({
+  key: ["ROOM_USER_POST"],
+  requester: roomUserRequest.RoomUserPost,
+});
+
+export const ROOM_USER_DELETE = createRequestWithQuery({
+  key: ["ROOM_USER_DELETE"],
+  requester: (roomUserId: string) => roomUserRequest.RoomUserDelete(roomUserId),
+});
+
+export const ROOM_USER_ALL_GET = createResourceWithQuery({
+  key: ["ROOM_USER_ALL_GET"],
+  fetcher: (studyRoomId: string) => roomUserRequest.RoomUserAllGet(studyRoomId),
+});
+
+export const ROOM_USER_STUDYROOM_GET = createResourceWithQuery({
+  key: ["ROOM_USER_STUDYROOM_GET"],
+  fetcher: (userId: string) => roomUserRequest.RoomUserStudyRoomGet(userId),
+});

--- a/src/api/roomUser/index.ts
+++ b/src/api/roomUser/index.ts
@@ -1,0 +1,6 @@
+import roomUserApiClient from "./roomUserApiClient";
+import RoomUserAPI from "./roomUserReq";
+
+const roomUserRequest = new RoomUserAPI(roomUserApiClient, "/room-user/");
+
+export default roomUserRequest;

--- a/src/api/roomUser/roomUserApiClient.ts
+++ b/src/api/roomUser/roomUserApiClient.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+import uriSelector from "../../utils/uriSelector";
+const roomUserApiClient = axios.create();
+
+roomUserApiClient.defaults.baseURL = uriSelector();
+
+export default roomUserApiClient;

--- a/src/api/roomUser/roomUserReq.ts
+++ b/src/api/roomUser/roomUserReq.ts
@@ -1,0 +1,55 @@
+import {
+  RoomUserPostRequest,
+  RoomUserPostResponse,
+  roomUserDeleteResponse,
+  roomUserAllGetResponse,
+  roomUserStudyRoomGetResponse,
+} from "./types/roomUserAPI";
+import RequestCore from "../common/RequestCore";
+
+class RoomUserAPI extends RequestCore {
+  public RoomUserPost = async (params?: RoomUserPostRequest) => {
+    const response = await this.apiRequest<
+      RoomUserPostRequest,
+      RoomUserPostResponse
+    >({
+      requestMethod: "POST",
+      requestData: params,
+      url: "one",
+    });
+
+    return response;
+  };
+
+  public RoomUserDelete = async (roomUserId: string) => {
+    const response = await this.apiRequest<undefined, roomUserDeleteResponse>({
+      requestMethod: "DELETE",
+      url: `one/${roomUserId}`,
+    });
+
+    return response;
+  };
+
+  public RoomUserAllGet = async (studyRoomId: string) => {
+    const response = await this.apiRequest<undefined, roomUserAllGetResponse>({
+      requestMethod: "GET",
+      url: `user/list/study-room/${studyRoomId}`,
+    });
+
+    return response;
+  };
+
+  public RoomUserStudyRoomGet = async (userId: string) => {
+    const response = await this.apiRequest<
+      undefined,
+      roomUserStudyRoomGetResponse
+    >({
+      requestMethod: "GET",
+      url: `study-room/list/user/${userId}`,
+    });
+
+    return response;
+  };
+}
+
+export default RoomUserAPI;

--- a/src/api/roomUser/types/roomUserAPI.ts
+++ b/src/api/roomUser/types/roomUserAPI.ts
@@ -1,0 +1,31 @@
+import { StudyRoomType } from "./../../studyRoom/types/studyRoomType";
+import { RoomUserType } from "./roomUserType";
+interface DefaultResultRes {
+  data?: object;
+  status: string;
+  message: string;
+  memo?: string;
+}
+
+export interface RoomUserPostRequest {
+  userDto: {
+    id: string;
+  };
+  studyRoomDto: {
+    id: string;
+  };
+}
+
+export interface RoomUserPostResponse extends DefaultResultRes {}
+
+// roomUserDeleteRequest 추가 파라미터 없음
+export interface roomUserDeleteResponse extends DefaultResultRes {}
+
+// export interface roomUserAllGetRequest
+export interface roomUserAllGetResponse extends DefaultResultRes {
+  data: RoomUserType[];
+}
+
+export interface roomUserStudyRoomGetResponse extends DefaultResultRes {
+  data: StudyRoomType[];
+}

--- a/src/api/roomUser/types/roomUserType.ts
+++ b/src/api/roomUser/types/roomUserType.ts
@@ -1,0 +1,15 @@
+import { StudyRoomType } from "./../../studyRoom/types/studyRoomType";
+export interface RoomUserType {
+  id: string;
+  userDto: {
+    id: string;
+    username: string;
+    roles: string;
+    profileName: string;
+    profileBirth: string;
+    profileImagePath: string;
+    alarmPermission: boolean;
+    friendAcceptance: boolean;
+  };
+  studyRoomDto: StudyRoomType;
+}

--- a/src/api/studyRoom/Resource.ts
+++ b/src/api/studyRoom/Resource.ts
@@ -1,0 +1,35 @@
+import studyRoomRequest from ".";
+import {
+  createRequest,
+  createResource,
+} from "../../hooks/react_query_hooks/useResource";
+
+export const STUDYROOM_ALL_GET = createResource({
+  key: [`STUDYROOM_ALL_GET`],
+  fetcher: studyRoomRequest.StudyRoomAllGet,
+});
+
+export const STUDYROOM_PUT = createRequest({
+  key: ["STUDYROOM_PUT"],
+  requester: studyRoomRequest.StudyRoomPut,
+});
+
+export const STUDYROOM_DELETE = createRequest({
+  key: ["STUDYROOM_DELETE"],
+  requester: studyRoomRequest.StudyRoomDelete,
+});
+
+export const STUDYROOM_CATEGORY_GET = createResource({
+  key: ["STUDYROOM_CATEGORY_GET"],
+  fetcher: studyRoomRequest.StudyRoomCategoryGet,
+});
+
+export const STUDYROOM_PW_PATCH = createRequest({
+  key: ["STUDYROOM_PW_PATCH"],
+  requester: studyRoomRequest.StudyRoomPwPatch,
+});
+
+export const STUDYROOM_PW_CHECK_POST = createRequest({
+  key: ["STUDYROOM_PW_CHECK_POST"],
+  requester: studyRoomRequest.StudyRoomPwCheckPost,
+});

--- a/src/api/studyRoom/index.ts
+++ b/src/api/studyRoom/index.ts
@@ -1,0 +1,6 @@
+import studyRoomApiClient from "./studyRoomApiClient";
+import StudyRoomAPI from "./studyRoomReq";
+
+const studyRoomRequest = new StudyRoomAPI(studyRoomApiClient, "/study-room/");
+
+export default studyRoomRequest;

--- a/src/api/studyRoom/studyRoomApiClient.ts
+++ b/src/api/studyRoom/studyRoomApiClient.ts
@@ -1,8 +1,8 @@
 import axios from "axios";
-import studyRoomUriSelector from "./studyRoomUriSelector";
+import uriSelector from "../../utils/uriSelector";
 
 const studyRoomApiClient = axios.create();
 
-studyRoomApiClient.defaults.baseURL = studyRoomUriSelector();
+studyRoomApiClient.defaults.baseURL = uriSelector();
 
 export default studyRoomApiClient;

--- a/src/api/studyRoom/studyRoomReq.ts
+++ b/src/api/studyRoom/studyRoomReq.ts
@@ -14,14 +14,15 @@ import {
 } from "./types/studyRoomAPI";
 import RequestCore from "../common/RequestCore";
 
-class studyRoomAPI extends RequestCore {
-  public StudyRoomPost = async (params: StudyRoomPostRequest) => {
+class StudyRoomAPI extends RequestCore {
+  public StudyRoomPost = async (params?: StudyRoomPostRequest) => {
     const response = await this.apiRequest<
       StudyRoomPostRequest,
       StudyRoomPostResponse
     >({
       requestMethod: "POST",
       requestData: params,
+      url: 'one'
     });
 
     return response;
@@ -30,70 +31,81 @@ class studyRoomAPI extends RequestCore {
   public StudyRoomAllGet = async () => {
     const response = await this.apiRequest<undefined, StudyRoomAllGetResponse>({
       requestMethod: "GET",
+      url: 'all'
     });
 
     return response;
   };
 
-  public StudyRoomPut = async (params: StudyRoomPutRequest) => {
+  public StudyRoomPut = async (params?: StudyRoomPutRequest) => {
     const response = await this.apiRequest<
       StudyRoomPutRequest,
       StudyRoomPutResponse
     >({
       requestMethod: "PUT",
       requestData: params,
+      url: 'one'
     });
 
     return response;
   };
 
-  public StudyRoomDelete = async (params: StudyRoomDeleteRequest) => {
+  // TODO: api uri에 맞게 수정 필요
+  public StudyRoomDelete = async (params?: StudyRoomDeleteRequest) => {
     const response = await this.apiRequest<
       StudyRoomDeleteRequest,
       StudyRoomDeleteResponse
     >({
       requestMethod: "DELETE",
       requestData: params,
+      url: 'one/'
     });
 
     return response;
   };
 
-  public StudyRoomCategoryGet = async (params: StudyRoomCategoryGetRequest) => {
+  public StudyRoomCategoryGet = async (
+    params?: StudyRoomCategoryGetRequest
+  ) => {
     const response = await this.apiRequest<
       StudyRoomCategoryGetRequest,
       StudyRoomCategoryGetResponse
     >({
       requestMethod: "GET",
       requestData: params,
+      url: 'list/study-category/'
     });
 
     return response;
   };
 
-  public StudyRoomPwPatch = async (params: StudyRoomPwPatchRequest) => {
+  public StudyRoomPwPatch = async (params?: StudyRoomPwPatchRequest) => {
     const response = await this.apiRequest<
       StudyRoomPwPatchRequest,
       StudyRoomPwPatchRequest
     >({
       requestMethod: "PATCH",
       requestData: params,
+      url: 'room-password',
     });
 
     return response;
   };
 
-  public StudyRoomPwCheckPost = async (params: StudyRoomPwCheckPostRequest) => {
+  public StudyRoomPwCheckPost = async (
+    params?: StudyRoomPwCheckPostRequest
+  ) => {
     const response = await this.apiRequest<
       StudyRoomPwCheckPostRequest,
       StudyRoomPwCheckPostResponse
     >({
       requestMethod: "POST",
       requestData: params,
+      url: 'room-password/check',
     });
 
     return response;
   };
 }
 
-export default StudyRoomPutRequest;
+export default StudyRoomAPI;

--- a/src/api/studyRoom/studyRoomUriSelector.ts
+++ b/src/api/studyRoom/studyRoomUriSelector.ts
@@ -3,9 +3,9 @@ import { isIncludesOneof } from "./../../utils/urlParser";
 const studyRoomUriSelector = () => {
   // 만약 테스트 서버가 따로 있을 때를 대비해서
   if (isIncludesOneof(["localhost"])) {
-    return "http://localhost:8080/api/study-room";
+    return "http://localhost:8080/api";
   }
-  return "http://localhost:8080/api/study-room";
+  return "http://localhost:8080/api";
 };
 
 export default studyRoomUriSelector;

--- a/src/containers/StudyRoom/StudyHome.tsx
+++ b/src/containers/StudyRoom/StudyHome.tsx
@@ -2,6 +2,7 @@ import React, { PropsWithChildren } from "react";
 import styled from "styled-components";
 import StudyList, { RoomType } from "../../components/StudyRoom/StudyList";
 import StudyModal from "../../components/StudyRoom/StudyModal/StudyModal";
+import { useStudyRoomAllGet } from "../../hooks/react_query_hooks/useStudyRoom";
 const roomListDummy: RoomType[] = [
   {
     id: "25e1d2ea-4063-4be5-ba28-ad7c226df2f5",
@@ -125,6 +126,7 @@ const roomListDummy: RoomType[] = [
   },
 ];
 const StudyHome = () => {
+  const { status, data } = useStudyRoomAllGet();
   return (
     <>
       {/* <StudyModal /> */}
@@ -133,7 +135,9 @@ const StudyHome = () => {
           <h1>스터디 룸</h1>
         </StudyHeader>
         <StudyBody>
-          <StudyList roomList={roomListDummy} />
+          {status === "success" && data && (
+            <StudyList roomList={data.data.data} />
+          )}
         </StudyBody>
       </StudyWrap>
     </>

--- a/src/containers/StudyRoom/StudyHome.tsx
+++ b/src/containers/StudyRoom/StudyHome.tsx
@@ -2,131 +2,14 @@ import React, { PropsWithChildren } from "react";
 import styled from "styled-components";
 import StudyList, { RoomType } from "../../components/StudyRoom/StudyList";
 import StudyModal from "../../components/StudyRoom/StudyModal/StudyModal";
+import { useRoomUserAllGet } from "../../hooks/react_query_hooks/useRoomUser";
 import { useStudyRoomAllGet } from "../../hooks/react_query_hooks/useStudyRoom";
-const roomListDummy: RoomType[] = [
-  {
-    id: "25e1d2ea-4063-4be5-ba28-ad7c226df2f5",
-    name: "스터디 룸1",
-    studyCategoryDto: {
-      id: "22acdcc3-0282-4031-b2f3-d14aaa1ce0c3",
-      name: "스터디카테고리1",
-      description: "스터디카테고리1의 설명 수정",
-    },
-    maximumNumberOfPeople: 3,
-    studyGoalTime: "",
-    roomPassword: "",
-    masterUserId: "",
-    createdAt: "2023-01-10T21:11:34",
-    updatedAt: "2023-02-11T16:03:31",
-  },
-  {
-    id: "f59cf358-5561-42a4-b2da-8e9ac730b346",
-    name: "스터디 룸3",
-    studyCategoryDto: {
-      id: "1651291b-83ef-40eb-8b24-0b7c5d7250ab",
-      name: "카테고리",
-      description: "카테고리 설명",
-    },
-    maximumNumberOfPeople: 2,
-    studyGoalTime: undefined,
-    roomPassword: undefined,
-    masterUserId: undefined,
-    createdAt: "2023-01-10T21:20:48",
-    updatedAt: undefined,
-  },
-  {
-    id: "eeaa932b-1f91-4d50-ac21-0521cdf4deea",
-    name: "스터디룸123123",
-    studyCategoryDto: {
-      id: "22acdcc3-0282-4031-b2f3-d14aaa1ce0c3",
-      name: "스터디카테고리1",
-      description: "스터디카테고리1의 설명 수정",
-    },
-    maximumNumberOfPeople: 3,
-    studyGoalTime: "PT3H",
-    roomPassword: undefined,
-    masterUserId: "3cfd73fe-e6fa-4a21-9a3a-dd1ba7689431",
-    createdAt: "2023-02-11T11:22:08",
-    updatedAt: undefined,
-  },
-  {
-    id: "8b9b8400-4c72-4163-abb5-6a3b2837b2d4",
-    name: "스터디룸123123",
-    studyCategoryDto: {
-      id: "22acdcc3-0282-4031-b2f3-d14aaa1ce0c3",
-      name: "스터디카테고리1",
-      description: "스터디카테고리1의 설명 수정",
-    },
-    maximumNumberOfPeople: 0,
-    studyGoalTime: "PT3H",
-    roomPassword: undefined,
-    masterUserId: "3cfd73fe-e6fa-4a21-9a3a-dd1ba7689431",
-    createdAt: "2023-02-11T11:42:57",
-    updatedAt: undefined,
-  },
-  {
-    id: "5b40299b-ea36-4da1-8cf4-702ac59ab712",
-    name: "스터디룸123123",
-    studyCategoryDto: {
-      id: "22acdcc3-0282-4031-b2f3-d14aaa1ce0c3",
-      name: "스터디카테고리1",
-      description: "스터디카테고리1의 설명 수정",
-    },
-    maximumNumberOfPeople: 0,
-    studyGoalTime: "PT3H",
-    roomPassword: undefined,
-    masterUserId: "3cfd73fe-e6fa-4a21-9a3a-dd1ba7689431",
-    createdAt: "2023-02-11T11:44:02",
-    updatedAt: undefined,
-  },
-  {
-    id: "e99efa3b-1270-4a4b-8291-364de3fc06c7",
-    name: "스터디룸123123",
-    studyCategoryDto: {
-      id: "22acdcc3-0282-4031-b2f3-d14aaa1ce0c3",
-      name: "스터디카테고리1",
-      description: "스터디카테고리1의 설명 수정",
-    },
-    maximumNumberOfPeople: 30,
-    studyGoalTime: "PT3H",
-    roomPassword: undefined,
-    masterUserId: "3cfd73fe-e6fa-4a21-9a3a-dd1ba7689431",
-    createdAt: "2023-02-11T11:45:41",
-    updatedAt: undefined,
-  },
-  {
-    id: "7f3aed24-5b30-468e-84d2-e1e1e622e29f",
-    name: "스터디룸123123123444",
-    studyCategoryDto: {
-      id: "22acdcc3-0282-4031-b2f3-d14aaa1ce0c3",
-      name: "스터디카테고리1",
-      description: "스터디카테고리1의 설명 수정",
-    },
-    maximumNumberOfPeople: 30,
-    studyGoalTime: "PT3H",
-    roomPassword: undefined,
-    masterUserId: "3cfd73fe-e6fa-4a21-9a3a-dd1ba7689431",
-    createdAt: "2023-02-11T14:04:07",
-    updatedAt: undefined,
-  },
-  {
-    id: "711268c8-373b-406a-a42e-6376593a252a",
-    name: "스터디룸1",
-    studyCategoryDto: {
-      id: "22acdcc3-0282-4031-b2f3-d14aaa1ce0c3",
-      name: "스터디카테고리1",
-      description: "스터디카테고리1의 설명 수정",
-    },
-    maximumNumberOfPeople: 3,
-    studyGoalTime: "PT3H",
-    roomPassword: undefined,
-    masterUserId: "3cfd73fe-e6fa-4a21-9a3a-dd1ba7689431",
-    createdAt: "2023-02-09T20:45:27",
-    updatedAt: undefined,
-  },
-];
+import localConsole from "../../utils/localConsole";
+
 const StudyHome = () => {
   const { status, data } = useStudyRoomAllGet();
+  // const { status, data } = useRoomUserAllGet();
+  if (status === "success") localConsole?.log(data?.data.data);
   return (
     <>
       {/* <StudyModal /> */}

--- a/src/hooks/react_query_hooks/useResource.ts
+++ b/src/hooks/react_query_hooks/useResource.ts
@@ -1,3 +1,4 @@
+import { request } from "http";
 import { useMutation, useQuery } from "react-query";
 
 type ResourceKeyType = [string] | [string, ...any[]] | string[];
@@ -5,6 +6,13 @@ type ResourceKeyType = [string] | [string, ...any[]] | string[];
 export function createResource<T, P>(resource: {
   key: ResourceKeyType;
   fetcher: (params?: P) => Promise<T>;
+}) {
+  return resource;
+}
+
+export function createResourceWithQuery<T, P>(resource: {
+  key: ResourceKeyType;
+  fetcher: (query: string, params?: P) => Promise<T>;
 }) {
   return resource;
 }
@@ -27,6 +35,16 @@ export function createRequest<T, P>(request: {
   return {
     key: request.key,
     requester: request.requester,
+  };
+}
+
+export function createRequestWithQuery<T, P>(request: {
+  key: ResourceKeyType;
+  requester: (query: string, params?: P) => Promise<T>;
+}) {
+  return {
+    key: request.key,
+    requester: (query: string) => request.requester(query),
   };
 }
 

--- a/src/hooks/react_query_hooks/useResource.ts
+++ b/src/hooks/react_query_hooks/useResource.ts
@@ -1,0 +1,42 @@
+import { useMutation, useQuery } from "react-query";
+
+type ResourceKeyType = [string] | [string, ...any[]] | string[];
+
+export function createResource<T, P>(resource: {
+  key: ResourceKeyType;
+  fetcher: (params?: P) => Promise<T>;
+}) {
+  return resource;
+}
+
+export function useResource<T, P>(resource: {
+  useQuery: typeof useQuery;
+  key: ResourceKeyType;
+  fetcher: (params?: P) => Promise<T>;
+  params?: P;
+}) {
+  return resource.useQuery(resource.key, () =>
+    resource.fetcher(resource?.params)
+  );
+}
+
+export function createRequest<T, P>(request: {
+  key: ResourceKeyType;
+  requester: (params?: P) => Promise<T>;
+}) {
+  return {
+    key: request.key,
+    requester: request.requester,
+  };
+}
+
+export function useSetResource<T, P>(request: {
+  useMutation: typeof useMutation;
+  key: ResourceKeyType;
+  requester: (params?: P) => Promise<T>;
+}) {
+  return request.useMutation({
+    mutationKey: request.key,
+    mutationFn: request.requester,
+  });
+}

--- a/src/hooks/react_query_hooks/useRoomUser.ts
+++ b/src/hooks/react_query_hooks/useRoomUser.ts
@@ -1,0 +1,53 @@
+import {
+  ROOM_USER_POST,
+  ROOM_USER_DELETE,
+  ROOM_USER_ALL_GET,
+  ROOM_USER_STUDYROOM_GET,
+} from "./../../api/roomUser/Resource";
+import { useResource, useSetResource } from "./useResource";
+import { useQuery, useMutation } from "react-query";
+
+export const useRoomUserPost = () => {
+  const queryState = useSetResource({
+    useMutation,
+    key: ROOM_USER_POST.key,
+    requester: ROOM_USER_POST.requester,
+  });
+
+  return queryState;
+};
+
+export const useRoomUserDelete = () => {
+  // TODO: roomUserId 가져와서 주입
+  const queryState = useSetResource({
+    useMutation,
+    key: ROOM_USER_DELETE.key,
+    requester: () => ROOM_USER_DELETE.requester("asdf"),
+  });
+
+  return queryState;
+};
+
+export const useRoomUserAllGet = () => {
+  // TODO: query 값 가져와서 주입
+  const query = "844e68a6-b8ed-4e88-9ed6-a98bbeb2a2a3";
+  const queryState = useResource({
+    useQuery,
+    key: ROOM_USER_ALL_GET.key,
+    fetcher: () => ROOM_USER_ALL_GET.fetcher(query),
+  });
+
+  return queryState;
+};
+
+export const useRoomStudyRoomGet = () => {
+  // TODO: query 값 가져와서 주입
+
+  const queryState = useResource({
+    useQuery,
+    key: ROOM_USER_STUDYROOM_GET.key,
+    fetcher: () => ROOM_USER_STUDYROOM_GET.fetcher("asdf"),
+  });
+
+  return queryState;
+};

--- a/src/hooks/react_query_hooks/useStudyRoom.ts
+++ b/src/hooks/react_query_hooks/useStudyRoom.ts
@@ -1,0 +1,70 @@
+import {
+  STUDYROOM_PUT,
+  STUDYROOM_DELETE,
+  STUDYROOM_CATEGORY_GET,
+  STUDYROOM_PW_PATCH,
+  STUDYROOM_PW_CHECK_POST,
+} from "./../../api/studyRoom/Resource";
+import { STUDYROOM_ALL_GET } from "../../api/studyRoom/Resource";
+import { useResource, useSetResource } from "./useResource";
+import { useQuery, useMutation } from "react-query";
+
+export const useStudyRoomAllGet = () => {
+  const queryState = useResource({
+    useQuery,
+    key: STUDYROOM_ALL_GET.key,
+    fetcher: STUDYROOM_ALL_GET.fetcher,
+  });
+
+  return queryState;
+};
+
+export const useStudyRoomPut = () => {
+  const queryState = useSetResource({
+    useMutation,
+    key: STUDYROOM_PUT.key,
+    requester: STUDYROOM_PUT.requester,
+  });
+
+  return queryState;
+};
+
+export const useStudyRoomDelete = () => {
+  const queryState = useSetResource({
+    useMutation,
+    key: STUDYROOM_DELETE.key,
+    requester: STUDYROOM_DELETE.requester,
+  });
+
+  return queryState;
+};
+
+export const useStudyRoomCategoryGet = () => {
+  const queryState = useResource({
+    useQuery,
+    key: STUDYROOM_CATEGORY_GET.key,
+    fetcher: STUDYROOM_CATEGORY_GET.fetcher,
+  });
+
+  return queryState;
+};
+
+export const useStudyRoomPwPatch = () => {
+  const queryState = useSetResource({
+    useMutation,
+    key: STUDYROOM_PW_PATCH.key,
+    requester: STUDYROOM_PW_PATCH.requester,
+  });
+
+  return queryState;
+};
+
+export const useStudyRoomPwCheckPost = () => {
+  const queryState = useSetResource({
+    useMutation,
+    key: STUDYROOM_PW_CHECK_POST.key,
+    requester: STUDYROOM_PW_CHECK_POST.requester,
+  });
+
+  return queryState;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,19 +1,17 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
-import { BrowserRouter } from 'react-router-dom';
-import './style/reset.css';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
+import { BrowserRouter } from "react-router-dom";
+import "./style/reset.css";
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById("root") as HTMLElement
 );
 root.render(
-  <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
-  </React.StrictMode>
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/src/utils/uriSelector.ts
+++ b/src/utils/uriSelector.ts
@@ -1,6 +1,5 @@
-import { isIncludesOneof } from "./../../utils/urlParser";
-
-const studyRoomUriSelector = () => {
+import { isIncludesOneof } from "./urlParser";
+const uriSelector = () => {
   // 만약 테스트 서버가 따로 있을 때를 대비해서
   if (isIncludesOneof(["localhost"])) {
     return "http://localhost:8080/api";
@@ -8,4 +7,4 @@ const studyRoomUriSelector = () => {
   return "http://localhost:8080/api";
 };
 
-export default studyRoomUriSelector;
+export default uriSelector;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1044,6 +1044,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
+  integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -2896,6 +2903,11 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2965,6 +2977,20 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -3702,7 +3728,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.0.4:
+detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -5976,6 +6002,11 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.2.0.tgz#278e98b7bea589b8baaf048c20aeb19eb7ad09d0"
   integrity sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6281,6 +6312,14 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
@@ -6330,6 +6369,11 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
@@ -6418,6 +6462,13 @@ multicast-dns@^7.2.5:
   dependencies:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -6590,6 +6641,11 @@ object.values@^1.1.0, object.values@^1.1.5, object.values@^1.1.6:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -7606,6 +7662,15 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-query@^3.39.3:
+  version "3.39.3"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.3.tgz#4cea7127c6c26bdea2de5fb63e51044330b03f35"
+  integrity sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
@@ -7818,6 +7883,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a"
@@ -7905,7 +7975,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -8816,6 +8886,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
### 작업한 내용
- 리액트 쿼리 설치 및 react-query 재사용 모듈 구현
   - RequestCore.ts : axios instance를 생성하는 class, 멤버 함수인 apiRequest는 HTTP 요청 종류와 요청 body, url을 파라미터로 받아 axios 요청을 생성한다.
   - studyRoomReq.ts: RequestCore를 상속하는 클래스로 studyroom 관련 api 전용 request core라고 보면 된다. 멤버 함수로 각각의 api 요청형식대로 requestCore의 apiRequest를 정의한다.
   - studyRoomApiClient.ts : axios.create()을 이용해 AxiosInstance를 생성한다. studyRoomUriSelector를 호출해 baseUrl을 설정한다.
   - index.ts: 실제로 studyRoomReq에서 정의한 클래스의 객체를 생성하고 이를 export한다. 즉, axios 요청을 할 때는 studyRoomRequest 객체를 불러와야 한다 (스터디룸 관련 요청)
   - hooks/react_query_hooks 안의 파일들은 axios instance를 이용해 reactquery에 적용하는 기능을 수행한다
   - useResource.ts: useQuery (GET)를 사용할 떄는 createResource, useResource / useMutation (PUT, POST, DELETE)을 사용할 때는 createRequest, useSetResource를 사용한다.
      - useQuery, useMutation을 사용할 때 필요한 값들을 type casing이 되도록 묶어주는 역할이라고 생각하면 된다
      - createResource, createRequest는 {key, fetcher/requester} 를 객체로 binding하여 반환하는 역할
      - useResource, useSetResource는 위의 create함수들에서 binding한 객체를 가지고 useMutation, useQuery를 실행하는 함수이다 
      - => create함수들은 ts에서 type정의하듯이 개발자가 개발할 때 타입 지원되도록 하는 역할, 실제 수행하는 작업은 없음, use함수들은 실제로 reactQuery문을 실행하는 부분! (react hook형태이기 때문에 딱 저 정해진 형식만 작성해야 하는게 아니라 useEffect, useState 등 다른 리액트 훅도 같이 활용할 수 있음)
      - 예시로 StudyHome.ts 파일 보시면 컴포넌트에서 데이터를 리액트 훅을 사용해 비동기 요청을 가져오는 거 확인할 수 있어요~
---

### 리뷰 시 참고사항
- createResource, createRequest는 api요청 url에 추가로 기입해야 하는 파라미터가 없을 때 사용하는 함수라 
room-user api에서 room user Delete 요청처럼 studyRoomId를 url에 추가해야할 때를 위해 createRequestWithQuery, createResourceWithQuery를 구현했습니다.
use할 때는 동일하게 useResource, useSetResource를 사용합니다
---

### 고민 중인 부분

---

### 참고 자료

---

Closes #27 